### PR TITLE
Encryption / net events / lobby fixes

### DIFF
--- a/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
+++ b/BeatTogether.DedicatedServer.Kernel/Managers/LobbyManager.cs
@@ -1,8 +1,8 @@
-﻿using BeatTogether.DedicatedServer.Kernel.Enums;
-using BeatTogether.DedicatedServer.Kernel.Abstractions;
-using BeatTogether.DedicatedServer.Messaging.Models;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Collections.Generic;
+using BeatTogether.DedicatedServer.Kernel.Abstractions;
+using BeatTogether.DedicatedServer.Kernel.Enums;
+using BeatTogether.DedicatedServer.Messaging.Models;
 using BeatTogether.DedicatedServer.Messaging.Packets.MultiplayerSession.MenuRpc;
 
 namespace BeatTogether.DedicatedServer.Kernel.Managers
@@ -38,7 +38,9 @@ namespace BeatTogether.DedicatedServer.Kernel.Managers
 
         public void Update()
         {
-            IPlayer manager = _playerRegistry.GetPlayer(_server.ManagerId);
+            if (!_playerRegistry.TryGetPlayer(_server.ManagerId, out var manager))
+                return;
+            
             BeatmapIdentifierNetSerializable? beatmap = GetSelectedBeatmap();
             
             if (beatmap != null && beatmap != _startedBeatmap)

--- a/BeatTogether.DedicatedServer.Kernel/PacketEncryptionLayer.cs
+++ b/BeatTogether.DedicatedServer.Kernel/PacketEncryptionLayer.cs
@@ -76,6 +76,7 @@ namespace BeatTogether.DedicatedServer.Kernel
                 new HMACSHA256(sendMacSourceArray)
             );
             _potentialEncryptionParameters[endPoint.Address] = encryptionParameters;
+            _encryptionParameters.TryRemove(endPoint, out _);
         }
 
         public void RemoveEncryptedEndPoint(IPEndPoint endPoint)


### PR DESCRIPTION
This PR contains the fixes we debugged today:

- Adds an exception handler to `PollEvents` to prevent silently failing and breaking net events
- Cleans up stale encryption parameters when accepting a new connection, fixes failed decryption on 2nd+ connection attempts
- Fixes the underlying issue in the lobby manager code that was throwing when the manager player data wasn't available yet
